### PR TITLE
Fix broken links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ This is the original SGI demo source code, compiled for the web using Emscripten
 
 ## Working demos
 - [Buttonfly](https://sgi-demos.github.io/)
-- [Bounce](https://sgi-demos.github.io/sgi-demos/bounce/web/bounce_full.html)
-- [Ideas](https://sgi-demos.github.io/sgi-demos/ideas/web/ideas_full.html)
-- [Insect](https://sgi-demos.github.io/sgi-demos/insect/web/insect_full.html)
-- [Jello](https://sgi-demos.github.io/sgi-demos/jello/web/jello_full.html)
-- [Logo](https://sgi-demos.github.io/sgi-demos/logo/web/logo_full.html)
-- [Twilight](https://sgi-demos.github.io/sgi-demos/twilight/web/twilight_full.html) 
+- [Bounce](https://sgi-demos.github.io/sgi-demos/demos/bounce/web/bounce_full.html)
+- [Ideas](https://sgi-demos.github.io/sgi-demos/demos/ideas/web/ideas_full.html)
+- [Insect](https://sgi-demos.github.io/sgi-demos/demos/insect/web/insect_full.html)
+- [Jello](https://sgi-demos.github.io/sgi-demos/demos/jello/web/jello_full.html)
+- [Logo](https://sgi-demos.github.io/sgi-demos/demos/logo/web/logo_full.html)
+- [Twilight](https://sgi-demos.github.io/sgi-demos/demos/twilight/web/twilight_full.html)
 
 ## Somewhat working demos
-- [Flight](https://sgi-demos.github.io/sgi-demos/flight/web/flight_full.html) (cockpit glitches, planes too slow in web version, night mode 'shimmers', no network play)
-- [Newave](https://sgi-demos.github.io/sgi-demos/newave/web/newave_full.html) (no mesh editing, no popup menus, only wireframe)
-- [Arena](https://sgi-demos.github.io/sgi-demos/arena/web/arena_full.html) (no network play)
+- [Flight](https://sgi-demos.github.io/sgi-demos/demos/flight/web/flight_full.html) (cockpit glitches, planes too slow in web version, night mode 'shimmers', no network play)
+- [Newave](https://sgi-demos.github.io/sgi-demos/demos/newave/web/newave_full.html) (no mesh editing, no popup menus, only wireframe)
+- [Arena](https://sgi-demos.github.io/sgi-demos/demos/arena/web/arena_full.html) (no network play)
 
 ## Build instructions
 


### PR DESCRIPTION
This also fixes the links on <https://github.com/sgi-demos>, which has the readme pinned.

Cool project!